### PR TITLE
feat: #4 Add pagination support for feed posts and explore posts

### DIFF
--- a/routes/posts.js
+++ b/routes/posts.js
@@ -6,23 +6,22 @@ const {
   deletePost,
   likePost,
   getSinglePost,
-  timelinePost,
-  getFollowingPosts,
   getAllPosts,
+  getUserFeedPosts,
 } = require("../controllers/post");
 const { isAuthenticated } = require("../middlewares/auth");
 
-// Get all posts
-router.get("/", isAuthenticated, getAllPosts);
+// Get all posts and crate post
+router
+  .route("/")
+  .get(isAuthenticated, getAllPosts)
+  .post(isAuthenticated, createPost);
 
-// Create a post
-router.post("/", isAuthenticated, createPost);
-
-// Update a post
-router.put("/:id", isAuthenticated, updatePost);
-
-// delete a post
-router.delete("/:id", isAuthenticated, deletePost);
+// Update a post and delete
+router
+  .route("/:id")
+  .put(isAuthenticated, updatePost)
+  .delete(isAuthenticated, deletePost);
 
 //Like and dislike a post
 router.put("/like/:id", isAuthenticated, likePost);
@@ -33,13 +32,10 @@ router
   .post(isAuthenticated, addComment)
   .delete(isAuthenticated, deleteComment);
 
-// Get following posts
-router.route("/followings").get(isAuthenticated, getFollowingPosts);
-
 // Get single posts
 router.route("/post/:id").get(isAuthenticated, getSinglePost);
 
-// get timeline posts
-router.get("/timeline/all", isAuthenticated, timelinePost);
+// get user feed posts
+router.get("/feed", isAuthenticated, getUserFeedPosts);
 
 module.exports = router;


### PR DESCRIPTION
This commit introduces pagination support for the feed posts and explore posts in the social API. It includes changes to the backend API endpoints. now frontend components fetch and display the posts in a paginated manner. The pagination logic ensures that only a limited number of posts are fetched at a time, improving performance and user experience.

Fixes #4